### PR TITLE
feat(audit,bootstrap): legacy range-numbered catalogue detection and mechanical migration (plan 0037)

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,19 @@ the optional layers you don't have yet, adding the chosen ones by merge.
 term, and `new-adr` offers to create a `domains/<slug>/` grouping when you
 file an ADR under a new domain.)
 
+**On an older number-range catalogue?** Early two-shape repos encoded the
+shape in the number — a cutoff in `CONVENTIONS.md`, a technology template
+at the boundary (`adr/0100-template.md` or your own number), technology
+records above it. That still works: `audit` recognises it, keeps checking
+it by its own range rules, and reports it as a single non-failing
+"migration available" note. Accept the offer (from `audit` or a
+`bootstrap` re-run) and the move is mechanical: your technology records
+are renumbered onto the end of the sequence in their original order,
+capability numbers stay put, `shape:` is written on every record, every
+in-repo reference follows, the boundary template is retired, and it lands
+as one commit listing every old-to-new pair. You see that map and confirm
+it before anything is written — and declining is a perfectly good answer.
+
 **Placement:** `AGENTS.md` and `CLAUDE.md` always stay at the repository
 root; everything else lives under a configurable **artefact root** —
 `.docflow/` (the default), `docs/`, or the repo root — chosen at bootstrap

--- a/USAGE.md
+++ b/USAGE.md
@@ -279,7 +279,7 @@ picks; a fully-specified request lets you skip straight through.
 | `/new-plan` | §5 step 3: create `plan/todo/NNNN`, name owning ADR(s), scope, exit criteria, dependencies, queue position. |
 | `/ship-item` | §5 steps 5–6: verify gate → integrate (ff or PR per Q4b) → `git mv` todo→done with footer → ADR `Accepted`→`Implemented` → regen INDEX → WORKLOG → live snapshot. The most order-sensitive operation; let the skill do it. |
 | `/add-convention` | Assesses whether a convention is worth codifying (triages out one-offs, duplicates, churn-prone, vague), routes it to AGENTS.md / CONVENTIONS.md / GLOSSARY / an ADR, then writes it. |
-| `/audit` | Lints the repo against its own conventions and reports a punch list — numbering, INDEX sync, plan coverage, section completeness, status validity, cross-refs, language mandate, and **ADR-privacy leaks into user-visible code**. Offers to fix the mechanical issues. |
+| `/audit` | Lints the repo against its own conventions and reports a punch list — numbering, INDEX sync, plan coverage, section completeness, status validity, cross-refs, language mandate, and **ADR-privacy leaks into user-visible code**. Offers to fix the mechanical issues, and offers the number-range migration (§5b) if your catalogue predates the `shape:` field. |
 | `/brainstorm` | Decomposes a problem into candidate ADRs + plan items with dependency edges and ordering. Proposes drafts only; writes nothing until approved, then hands off to `/new-adr` and `/new-plan`. |
 | `/agent-wave` | Orchestrates parallel worktree subagents over the queue. Asks wave width, budget (items/waves; hours as a soft cap), and supervision (checkpoint vs. continuous). Requires multi-agent mode; refuses mode 1. |
 | `/rollup` | For a **multi-repo product**: from the home repo, aggregate every member repo's `INDEX` into one derived, product-wide roll-up. Members not checked out are listed as "not aggregated this run". |
@@ -442,6 +442,57 @@ has distinct areas, or the flat list grows large enough to be hard to scan.
 See the [methodology](https://evolvehq.github.io/docflow/methodology/#47-grouping-adrs-by-domain)
 for the formal treatment.
 
+## 5b. Catalogues on the older number-range scheme
+
+Repos scaffolded before the shape became a declared field encode it in
+the **number**: `CONVENTIONS.md` §ADR Shapes records a cutoff, capability
+records sit below it, technology records at or above, and the technology
+template sits at the boundary as `adr/0100-template.md` (or whatever
+number the project chose). That scheme has a real limit — a capability
+block that reaches the cutoff has nowhere to grow, because the technology
+block already occupies the numbers above it.
+
+**Nothing breaks.** Either signal — the recorded cutoff or a template
+numbered off `0000` — is enough for the skills to recognise the scheme.
+`audit` then applies the range rules exactly as before (contiguous within
+each block, the gap at the cutoff expected, no Shape column required), so
+a repo that passed keeps passing, and adds **one** non-failing finding at
+severity *migration available*. `new-adr` keeps placing records on the
+correct side of the cutoff, and stops rather than crossing it if a block
+is full.
+
+**The migration is offered, never applied.** `audit` offers it after the
+punch list; a `bootstrap` re-run offers it in the existing-repo step. Both
+show the same dry run first:
+
+| old | new | |
+|---|---|---|
+| `0001`–`0012` | unchanged | capability records keep their numbers |
+| `0101` | `0013` | technology records take the numbers after the last capability one… |
+| `0102` | `0014` | …in their original order |
+| `0104` | `0015` | gaps in the old technology block are closed |
+
+Confirm that map and the migration lands as **one commit** that: renumbers
+the technology files; writes `shape:` on every record (capability ones
+too); rewrites every in-repo reference that named a moved number —
+`depends-on`, supersede links, relative `adr/NNNN-*.md` links, `INDEX.md`,
+domain `README.md` listings, and `plan/todo/` owner lines; replaces the
+boundary template with `adr/0000-template-technology.md`; rewrites §ADR
+Shapes to the declared-field form (and drops any "recorded exception"
+clause for the seed record); and regenerates `INDEX.md` with the Shape
+column. Afterwards the catalogue passes the two-shape checks with no
+manual edit.
+
+**What is deliberately left alone:** `plan/done/` footers, commit
+messages, and tags. Those are history, and history is not rewritten — the
+migration commit's old-to-new list is the record that ties the two
+numberings together. In a multi-repo product, other repos' references to
+the renumbered records show up as dangling in the next cross-repo audit,
+exactly as they would for any renumbering; fix them in the referring repo.
+
+**Declining is fine.** The repo keeps the range scheme and keeps passing;
+the offer comes back on the next audit.
+
 ## 6. Customising or extending
 
 The templates are deliberately small and self-contained. To customise:
@@ -472,6 +523,11 @@ The skill is idempotent in spirit, but be careful: re-running on a
 repo that already has scaffolded files will trigger the "existing
 repo" path and ask Q9 about conflicts. Use it intentionally — to add
 the parts you skipped the first time, not to wipe and rebuild.
+
+A re-run on a repo using the older number-range scheme offers the
+migration onto the declared `shape:` field instead of the second-shape
+layer (that repo already has both shapes) — see §5b. It shows the
+old-to-new number map and writes nothing until you confirm it.
 
 ## 8. Updating the plugin
 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -256,6 +256,19 @@ New work now follows the same loop: `/new-adr` → `/new-plan` → `/ship-item`.
    ```
    ⚠ src/api/errors.ts:42  "see ADR 0007" in a customer-facing error string
    ```
+4. On a catalogue that predates the `shape:` field, the report ends with
+   one non-failing note and an offer:
+
+   ```
+   ℹ migration available  shape encoded by number range (cutoff in
+     CONVENTIONS.md §ADR Shapes; adr/0100-template.md at the boundary)
+     — catalogue valid and passing under the range rules
+   → migrate onto the declared shape: field?  0101 → 0013, 0102 → 0014,
+     0104 → 0015 (capability numbers unchanged)  [y/N]
+   ```
+
+   Answer `y` and it lands as one commit listing every pair; answer `N`
+   and the repo carries on unchanged. See USAGE §5b.
 
 ### brainstorm
 

--- a/docs/methodology.md
+++ b/docs/methodology.md
@@ -159,6 +159,25 @@ repository using one shape omits the field entirely and its index carries
 no such column. (A federation roll-up MAY add the column when any member
 declares two shapes — §5.)
 
+Earlier revisions of this method encoded the shape as a **number range** —
+capability records below a recorded cutoff, technology records at or
+above, the technology template numbered at the boundary. That encoding is
+superseded, for three reasons: it overflows (a capability block reaching
+the cutoff cannot grow, because the technology block already holds the
+numbers above it, and widening the boundary collides with real records);
+it forces an exception, since the record that adopts the method is itself
+a technology-shaped decision that must be first in the sequence; and it is
+per-shape numbering, which the flat-identity rule (§4.6) already rejects
+for domains. A repository still on it remains **conformant** — it is
+checked by its own range rules — and MAY migrate: the technology records
+take the numbers after the last capability one in their original order,
+capability numbers are unchanged, `shape:` is written on every record, and
+every in-repository reference follows. The migration MUST be confirmed
+against a shown old-to-new map before any file is written, and MUST land
+as one commit whose message lists every pair — outside the repository,
+history is not rewritten, so that list is the only bridge between the two
+numberings.
+
 ### 4.4 Status — the state machine
 
 States: `Proposed`, `Accepted`, `Implemented`, `Superseded`, `Deprecated`.

--- a/evals/README.md
+++ b/evals/README.md
@@ -43,7 +43,29 @@ subagent eval ran against `origin/main` and so saw the pre-expansion
 - Deterministic layer: **done**. `npm run evals` self-check passes
   against this repo as a fixture.
 - Behavioural layer: **authored** as `behavioural.workflow.mjs` with
-  cases for `new-adr`, `ship-item`, `bootstrap`. The `new-adr` path has
+  cases for `new-adr`, `ship-item`, `bootstrap`, and the legacy-range
+  migration. The `new-adr` path has
   been demonstrated live (a worktree subagent produced a contiguous ADR +
   INDEX row; the static gate passed). Running the full suite as a green
   release gate is the remaining step for plan item 0002.
+
+## Fixtures
+
+`fixtures/<name>/` holds a checked-in repository state a case needs and
+this repo cannot itself be. Each fixture carries a `README.md` saying
+what makes it what it is and what a case should expect from it.
+
+- **`fixtures/legacy-range/`** — a range-numbered catalogue as bootstrap
+  scaffolded a two-shape repo before the shape became a declared field:
+  a cutoff in `CONVENTIONS.md`, `adr/0100-template.md` at the boundary,
+  capability `0001`–`0003` below it, technology `0101`–`0102` above,
+  cross-references both ways, and the seed record as the exception the
+  range forces. It feeds the legacy-detection and migration case
+  (adr/0035-range-numbered-catalogue-migration.md AC1–AC9).
+
+A fixture is a directory of files, not a git repo. A case that migrates
+or otherwise mutates one **copies it to a scratch directory first** —
+mutating it in place destroys the state it exists to provide. A
+deterministic self-check case guards each fixture's defining properties,
+so a fixture that silently rots fails `npm run evals` rather than
+quietly making a behavioural case vacuous.

--- a/evals/assertions.mjs
+++ b/evals/assertions.mjs
@@ -9,14 +9,44 @@ import { join } from 'node:path';
 const read = (root, rel) =>
   readFileSync(join(root, rel), 'utf8').replace(/\r\n/g, '\n');
 
-// List catalogue ADRs (excludes the 0000 template), sorted by number.
+// List catalogue ADRs, sorted by number. Templates are not decisions:
+// both 0000- files are excluded, and so is a template numbered at a
+// legacy range boundary (e.g. adr/0100-template.md).
 export function listAdrs(root) {
   const dir = join(root, 'adr');
   if (!existsSync(dir)) return [];
   return readdirSync(dir)
-    .filter((f) => /^\d{4}-.+\.md$/.test(f) && f !== '0000-template.md')
+    .filter((f) => /^\d{4}-.+\.md$/.test(f))
+    .filter((f) => !f.startsWith('0000-') && !/^\d{4}-template\.md$/.test(f))
     .map((f) => ({ num: Number(f.slice(0, 4)), file: f }))
     .sort((a, b) => a.num - b.num);
+}
+
+// Template files numbered other than 0000 — the legacy boundary template.
+export function listBoundaryTemplates(root) {
+  const dir = join(root, 'adr');
+  if (!existsSync(dir)) return [];
+  return readdirSync(dir)
+    .filter((f) => /^\d{4}-template\.md$/.test(f) && !f.startsWith('0000-'));
+}
+
+// Every text-like file under root, relative to it (skips .git).
+function walk(root, rel = '') {
+  const out = [];
+  const dir = rel ? join(root, rel) : root;
+  if (!existsSync(dir)) return out;
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    if (entry.name === '.git') continue;
+    const child = rel ? `${rel}/${entry.name}` : entry.name;
+    if (entry.isDirectory()) out.push(...walk(root, child));
+    else if (entry.name.endsWith('.md')) out.push(child);
+  }
+  return out;
+}
+
+// The declared shape of an ADR: its `shape:` field, or null when absent.
+export function adrShape(root, file) {
+  return frontmatter(read(root, `adr/${file}`)).shape || null;
 }
 
 function frontmatter(text) {
@@ -88,6 +118,125 @@ export function assertAdrStatus(root, num, expected) {
   const status = frontmatter(read(root, `adr/${adr.file}`)).status;
   if (status !== expected) {
     throw new Error(`ADR ${padded} status "${status}", expected "${expected}"`);
+  }
+}
+
+// The catalogue is on the LEGACY RANGE ENCODING: shape carried by the
+// number, not by a field. `cutoff` is the first technology number;
+// `shapeExceptions` names ADR numbers below it that are technology-shaped
+// anyway (the seed record the range encoding forces an exception for).
+export function assertLegacyRange(root, { cutoff, shapeExceptions = [] }) {
+  const conventions = read(root, 'CONVENTIONS.md');
+  const boundary = String(cutoff).padStart(4, '0');
+  if (!conventions.includes(boundary)) {
+    throw new Error(`CONVENTIONS.md records no cutoff at ${boundary}`);
+  }
+  const templates = listBoundaryTemplates(root);
+  if (!templates.length) {
+    throw new Error('no boundary-numbered template — not a legacy catalogue');
+  }
+  const adrs = listAdrs(root);
+  if (!adrs.length) throw new Error('no ADRs in the fixture');
+  for (const adr of adrs) {
+    if (adrShape(root, adr.file)) {
+      throw new Error(`${adr.file} carries a shape: field — not legacy`);
+    }
+    const body = read(root, `adr/${adr.file}`);
+    const isTechBody = body.includes('\n## Decision\n');
+    const expectTech = adr.num >= cutoff || shapeExceptions.includes(adr.num);
+    if (isTechBody !== expectTech) {
+      throw new Error(
+        `${adr.file}: sections are ${isTechBody ? 'technology' : 'capability'}` +
+        `-shaped, but the range says ${expectTech ? 'technology' : 'capability'}`,
+      );
+    }
+  }
+  // Contiguous WITHIN each block; the gap at the cutoff is expected.
+  for (const block of [adrs.filter((a) => a.num < cutoff),
+                       adrs.filter((a) => a.num >= cutoff)]) {
+    block.forEach((adr, i) => {
+      if (adr.num !== block[0].num + i) {
+        throw new Error(`legacy block not contiguous at ${adr.file}`);
+      }
+    });
+  }
+  if (/\|\s*Shape\s*\|/.test(read(root, 'INDEX.md'))) {
+    throw new Error('INDEX.md carries a Shape column — not legacy');
+  }
+  return adrs;
+}
+
+// The catalogue has been MIGRATED onto the declared field. `map` is the
+// old-to-new number map the migration was confirmed against.
+export function assertMigratedToDeclaredShape(root, { map }) {
+  const boundary = listBoundaryTemplates(root);
+  if (boundary.length) {
+    throw new Error(`boundary template not retired: ${boundary.join(', ')}`);
+  }
+  assertTree(root, ['adr/0000-template.md', 'adr/0000-template-technology.md']);
+  const adrs = assertContiguousAdrs(root);
+  for (const adr of adrs) {
+    const shape = adrShape(root, adr.file);
+    if (shape !== 'capability' && shape !== 'technology') {
+      throw new Error(`${adr.file}: shape: is "${shape}" — expected capability or technology`);
+    }
+  }
+  for (const [oldNum, newNum] of Object.entries(map)) {
+    const moved = adrs.find((a) => a.num === Number(newNum));
+    if (!moved) throw new Error(`no ADR at the migrated number ${newNum}`);
+    if (adrShape(root, moved.file) !== 'technology') {
+      throw new Error(`${moved.file}: a moved ADR must be shape: technology`);
+    }
+    if (adrs.some((a) => a.num === Number(oldNum))) {
+      throw new Error(`ADR ${oldNum} still present at its old number`);
+    }
+  }
+  assertIndexSync(root);
+  if (!/\|\s*Shape\s*\|/.test(read(root, 'INDEX.md'))) {
+    throw new Error('INDEX.md has no Shape column after migration');
+  }
+  const conventions = read(root, 'CONVENTIONS.md');
+  if (!conventions.includes('shape:')) {
+    throw new Error('CONVENTIONS.md §ADR Shapes does not describe the field');
+  }
+  if (/recorded exception/i.test(conventions)) {
+    throw new Error('CONVENTIONS.md still carries the seed exception clause');
+  }
+  return adrs;
+}
+
+// No file still references a renumbered ADR — except plan/done/ footers
+// and git history, which the migration deliberately leaves as history.
+export function assertReferencesRewritten(root, { map }) {
+  const stale = [];
+  for (const rel of walk(root)) {
+    if (rel.startsWith('plan/done/')) continue;
+    if (rel === 'README.md') continue; // the fixture's own notes
+    const text = read(root, rel);
+    for (const oldNum of Object.keys(map)) {
+      const padded = String(oldNum).padStart(4, '0');
+      if (new RegExp(`\\b${padded}\\b`).test(text)) stale.push(`${rel} -> ${padded}`);
+    }
+  }
+  if (stale.length) {
+    throw new Error(`stale references to renumbered ADRs: ${stale.join(', ')}`);
+  }
+}
+
+// plan/done/ footers still name the OLD numbers they were written with:
+// shipped entries are history, and history is not rewritten. `numbers` is
+// the set of pre-migration numbers those footers actually cited.
+export function assertHistoryPreserved(root, { numbers }) {
+  const dir = join(root, 'plan/done');
+  const done = existsSync(dir) ? readdirSync(dir) : [];
+  const text = done.map((f) => read(root, `plan/done/${f}`)).join('\n');
+  for (const num of numbers) {
+    const padded = String(num).padStart(4, '0');
+    if (!text.includes(padded)) {
+      throw new Error(
+        `plan/done/ no longer names the old number ${padded} — history was rewritten`,
+      );
+    }
   }
 }
 

--- a/evals/behavioural.workflow.mjs
+++ b/evals/behavioural.workflow.mjs
@@ -51,6 +51,36 @@ const CASES = [
       'verify.mjs output + exit code.',
   },
   {
+    key: 'legacy-range-migration',
+    prompt:
+      'Behavioural eval of the docflow `audit` skill against a RANGE-NUMBERED catalogue. Work ONLY in your ' +
+      'worktree; do NOT commit or push, and do NOT modify evals/fixtures/legacy-range itself. ' +
+      'FIRST copy evals/fixtures/legacy-range to a scratch directory (e.g. ../legacy-scratch) and work THERE — ' +
+      'that copy is the repo under audit for the rest of this case. ' +
+      'Read plugins/docflow/skills/audit/SKILL.md, then: ' +
+      '(1) DETECTION — audit the scratch repo and report whether it recognised the legacy range encoding, from ' +
+      'which signal(s), and confirm the run produced exactly ONE "migration available" finding, that the finding ' +
+      'is NOT a failure, and that the numbering / INDEX / section checks PASSED under the range rules ' +
+      '(gap at the cutoff expected, no Shape column required, the 0100 template not counted as an ADR). ' +
+      '(2) OFFER — produce the dry-run old-to-new number map WITHOUT writing anything, and state the file count ' +
+      'changed so far (it must be zero). The expected map is 0101 -> 0004 and 0102 -> 0005, with 0001-0003 ' +
+      'unchanged and 0001 keeping its number. ' +
+      '(3) MIGRATION — confirm the map, then apply the migration to the scratch repo exactly as the skill ' +
+      'specifies (renumber, stamp shape: on every ADR, rewrite depends-on / supersede links / relative ' +
+      'adr/NNNN-*.md links / INDEX rows / domains listings / plan/todo owning-ADR lines, retire the boundary ' +
+      'template in favour of adr/0000-template-technology.md, rewrite CONVENTIONS §ADR Shapes and drop the ' +
+      'recorded-exception clause, regenerate INDEX with the Shape column). Leave plan/done footers alone. ' +
+      'State the single commit message you WOULD use, listing every old-to-new pair (do not actually commit). ' +
+      '(4) POST-MIGRATION AUDIT — re-run the checks with the legacy rules off and confirm the catalogue passes ' +
+      'with NO manual edit. ' +
+      'THEN run the deterministic assertions from the docflow checkout against the scratch repo: ' +
+      'node -e "import(\'./evals/assertions.mjs\').then(m=>{const r=process.argv[1];const map={\'0101\':\'0004\',\'0102\':\'0005\'};' +
+      'm.assertMigratedToDeclaredShape(r,{map});m.assertReferencesRewritten(r,{map});' +
+      'm.assertHistoryPreserved(r,{numbers:[\'0101\']});console.log(\'OK\')})" <scratch-repo-path> ' +
+      'PASS only if all four steps hold AND that command prints OK. Report each step, the map you produced, ' +
+      'the commit message, and the assertion output.',
+  },
+  {
     key: 'bootstrap',
     prompt:
       'Behavioural eval of the docflow `bootstrap` skill. Work ONLY in your worktree; do NOT push. ' +

--- a/evals/cases.mjs
+++ b/evals/cases.mjs
@@ -8,9 +8,21 @@ import { dirname, join } from 'node:path';
 import {
   assertTree, assertContiguousAdrs, assertIndexSync, assertAdrStatus,
   assertPlanShipped, assertAbsent, assertFileContains,
+  assertLegacyRange, assertMigratedToDeclaredShape,
+  assertReferencesRewritten, assertHistoryPreserved,
 } from './assertions.mjs';
 
-const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..');
+const evalsDir = dirname(fileURLToPath(import.meta.url));
+const repoRoot = join(evalsDir, '..');
+
+// The range-numbered fixture and the migration it is expected to take:
+// capability 0001-0003 keep their numbers, technology 0101/0102 move onto
+// the end of the sequence in their original order. 0001 is the seed —
+// technology-shaped inside the capability range — and does NOT move.
+const legacyFixture = join(evalsDir, 'fixtures/legacy-range');
+const LEGACY_CUTOFF = 100;
+const LEGACY_MAP = { '0101': '0004', '0102': '0005' };
+const LEGACY_DONE_NUMBERS = ['0101'];
 
 export const cases = [
   {
@@ -29,6 +41,56 @@ export const cases = [
       ]);
       assertContiguousAdrs(repo);
       assertIndexSync(repo);
+    },
+  },
+  {
+    // Runs NOW. Guards the fixture itself: if it ever stops being a
+    // range-numbered catalogue, the migration case below is testing
+    // nothing. No agent needed — the fixture is checked-in state.
+    name: 'self-check: the legacy-range fixture is still range-numbered',
+    skill: null,
+    agentDependent: false,
+    repo: legacyFixture,
+    assert(repo) {
+      assertTree(repo, [
+        'CONVENTIONS.md', 'AGENTS.md', 'INDEX.md',
+        'adr/0000-template.md', 'adr/0100-template.md',
+        'adr/0001-record-architecture-decisions.md',
+        'adr/0101-markdown-files-in-git.md',
+        'domains/platform/README.md', 'plan/todo', 'plan/done',
+      ]);
+      assertAbsent(repo, ['adr/0000-template-technology.md']);
+      // Cutoff recorded, boundary template present, no shape: fields, no
+      // Shape column, contiguous within each block, the seed excepted.
+      assertLegacyRange(repo, { cutoff: LEGACY_CUTOFF, shapeExceptions: [1] });
+      // References run both ways across the boundary.
+      assertFileContains(repo, 'adr/0003-queue-driven-implementation.md',
+        'adr/0101-markdown-files-in-git.md');
+      assertFileContains(repo, 'adr/0101-markdown-files-in-git.md',
+        'adr/0002-searchable-decision-catalogue.md');
+      assertFileContains(repo, 'plan/todo/0001-verify-script-coverage.md',
+        'adr/0102-static-verify-script.md');
+    },
+  },
+  {
+    // Detection, the offer, the migration, and the post-migration audit.
+    // The subagent works on a COPY of the fixture (see the behavioural
+    // workflow); `repo` is that copy's path at assert time.
+    name: 'audit: legacy range detected, migration offered and applied',
+    skill: 'audit',
+    inputs: { fixture: 'evals/fixtures/legacy-range', confirm: 'yes' },
+    assert(repo) {
+      // AC4/AC5/AC6/AC7: renumbered in order, field on every ADR, boundary
+      // template retired, conventions rewritten, INDEX with Shape column.
+      assertMigratedToDeclaredShape(repo, { map: LEGACY_MAP });
+      // AC5: every in-catalogue reference followed the renumbering...
+      assertReferencesRewritten(repo, { map: LEGACY_MAP });
+      // ...and plan/done footers did not.
+      assertHistoryPreserved(repo, { numbers: LEGACY_DONE_NUMBERS });
+      // The seed keeps its number and declares the shape it always had.
+      assertFileContains(repo, 'adr/0001-record-architecture-decisions.md',
+        'shape: technology');
+      assertPlanShipped(repo, 'adopt-the-method');
     },
   },
   {

--- a/evals/fixtures/legacy-range/AGENTS.md
+++ b/evals/fixtures/legacy-range/AGENTS.md
@@ -1,0 +1,25 @@
+# AGENTS.md
+
+Guidance for coding agents working in this repository.
+
+## Hard rules when editing ADRs
+
+- **One decision per ADR.** Splits become new ADRs that supersede.
+- **Status lifecycle:** `Proposed -> Accepted -> Implemented ->
+  (Superseded | Deprecated)`.
+- **Capability ADR section order:** metadata -> Context -> Capability
+  statement -> User stories / scenarios -> Acceptance criteria -> Out of
+  scope -> Open questions -> References -> Revision History -> Approvals.
+- **Technology ADR section order:** metadata -> Context -> Decision ->
+  Rationale -> Consequences -> Acceptance criteria -> Out of scope ->
+  Open questions -> References -> Revision History -> Approvals.
+- **Shape is the number range.** Capability ADRs are numbered below
+  `0100`; technology ADRs from `0100` onwards. The technology template
+  sits at the boundary as `adr/0100-template.md`.
+- **Acceptance criteria are testable and numbered.**
+- **ADRs are internal artefacts — never user-visible.**
+
+## Plan folder
+
+`plan/todo/NNNN-<slug>.md` is pending work; `git mv` to
+`plan/done/<YYYY-MM-DD>-<slug>.md` is the completion event.

--- a/evals/fixtures/legacy-range/CONVENTIONS.md
+++ b/evals/fixtures/legacy-range/CONVENTIONS.md
@@ -1,0 +1,51 @@
+# Conventions
+
+## Project
+
+Project name: legacy-range.
+
+Artefact root: `.` — the repository root.
+
+Language: en-GB throughout.
+
+Assessment depth: full.
+
+## ADR Files
+
+ADR filenames use `NNNN-kebab-case-slug.md`, zero-padded to 4 digits,
+contiguous within each shape's range.
+
+Status lifecycle: `Proposed -> Accepted -> Implemented ->
+(Superseded | Deprecated)`.
+
+Cross-references link by relative path to `adr/NNNN-*.md`.
+
+## ADR Shapes
+
+Capability ADRs (`0001`-`0099`) describe what the system must do. They
+use `adr/0000-template.md` with sections: Context, Capability
+statement, User stories / scenarios, Acceptance criteria, Out of
+scope, Open questions, References, Revision History, Approvals.
+
+Technology ADRs (`0100` onwards) describe how the system is built.
+They use `adr/0100-template.md` with sections: Context, Decision,
+Rationale, Consequences, Acceptance criteria, Out of scope, Open
+questions, References, Revision History, Approvals.
+
+Technology ADR Rationale must name alternatives considered and give
+specific reasons they were rejected.
+
+**Recorded exception.** `adr/0001-record-architecture-decisions.md` is a
+technology-shaped decision that sits in the capability range, because the
+ADR that adopts the method must be the first in the catalogue. It is the
+one ADR whose shape does not follow its number.
+
+## Plan Folder
+
+- `plan/todo/NNNN-<slug>.md` — pending work, lower numbers run first.
+- `plan/done/<YYYY-MM-DD>-<slug>.md` — shipped work, chronological.
+
+## Git Contract
+
+Conventional Commits, with a mandatory `Rationale:` footer on any commit
+touching an ADR. Signed commits: yes.

--- a/evals/fixtures/legacy-range/INDEX.md
+++ b/evals/fixtures/legacy-range/INDEX.md
@@ -1,0 +1,11 @@
+# ADR Index
+
+Generated from ADR metadata. Do not hand-edit.
+
+| ADR | Title | Status | Date |
+|-----|-------|--------|------|
+| [0001](adr/0001-record-architecture-decisions.md) | Record architecture decisions | Implemented | 2026-01-12 |
+| [0002](adr/0002-searchable-decision-catalogue.md) | A searchable decision catalogue | Implemented | 2026-01-19 |
+| [0003](adr/0003-queue-driven-implementation.md) | Queue-driven implementation | Accepted | 2026-02-02 |
+| [0101](adr/0101-markdown-files-in-git.md) | Markdown files in git as the store | Implemented | 2026-01-19 |
+| [0102](adr/0102-static-verify-script.md) | A static verify script as the gate | Accepted | 2026-02-09 |

--- a/evals/fixtures/legacy-range/README.md
+++ b/evals/fixtures/legacy-range/README.md
@@ -1,0 +1,38 @@
+# legacy-range fixture
+
+A **range-numbered** ADR catalogue, as `bootstrap` scaffolded a two-shape
+repo before the shape became a declared `shape:` metadata field. It is the
+input for the legacy-detection and migration eval (adr/0035 AC1–AC9).
+
+What makes it legacy:
+
+- `CONVENTIONS.md` §ADR Shapes records a **cutoff** (`0100`) and a
+  "recorded exception" clause for the seed ADR.
+- `adr/0100-template.md` — the technology template numbered at the
+  boundary, not `0000`.
+- Capability ADRs `0001`–`0003` below the cutoff, technology ADRs
+  `0101`–`0102` at or above it, with the gap between the blocks.
+- No ADR carries a `shape:` field; `INDEX.md` has no Shape column.
+- `0001` is the seed: technology-shaped but below the cutoff — the
+  exception the range encoding forces.
+
+Cross-references run **both ways**: capability `0003` depends on
+technology `0101`, technology `0102` depends on capability `0002` and on
+technology `0101`. `plan/todo/`, `plan/done/`, and `domains/platform/`
+all name numbers that move.
+
+Expected migration (highest capability ADR is `0003`):
+
+| old | new |
+|---|---|
+| `0101-markdown-files-in-git` | `0004-markdown-files-in-git` |
+| `0102-static-verify-script` | `0005-static-verify-script` |
+
+`0001`–`0003` keep their numbers; `0001` keeps its number **and** gains
+`shape: technology` — a technology-shaped ADR inside the old capability
+range is not renumbered, it just declares what it always was.
+`plan/done/` footers keep the old numbers: they are history.
+
+The fixture is a directory of files, not a git repo. A case that needs to
+run the migration copies it into a scratch directory first and works
+there — never in place, or the fixture stops being a legacy catalogue.

--- a/evals/fixtures/legacy-range/adr/0000-template.md
+++ b/evals/fixtures/legacy-range/adr/0000-template.md
@@ -1,0 +1,37 @@
+---
+adr: NNNN
+title: <Sentence case title>
+status: Proposed
+date: YYYY-MM-DD
+owner: <name>
+supersedes:
+superseded-by:
+depends-on: []
+tags: []
+---
+
+# ADR NNNN — <title>
+
+## Context
+
+## Capability statement
+
+## User stories / scenarios
+
+## Acceptance criteria
+
+## Out of scope
+
+## Open questions
+
+## References
+
+## Revision History
+
+| Date | Revision | Author | Change |
+|------|----------|--------|--------|
+
+## Approvals
+
+| Role | Name | Date | Signature |
+|------|------|------|-----------|

--- a/evals/fixtures/legacy-range/adr/0001-record-architecture-decisions.md
+++ b/evals/fixtures/legacy-range/adr/0001-record-architecture-decisions.md
@@ -1,0 +1,68 @@
+---
+adr: 0001
+title: Record architecture decisions
+status: Implemented
+date: 2026-01-12
+owner: eval-bot
+supersedes:
+superseded-by:
+depends-on: []
+tags: [fixture]
+---
+
+# ADR 0001 — Record architecture decisions
+
+## Context
+
+This repository had no written record of why it is built the way it is.
+Decisions lived in review threads and in people's heads.
+
+## Decision
+
+Adopt the documentation-led, ADR-driven method: one decision per record,
+a contiguous catalogue under `adr/`, a queue under `plan/`, and the
+authoring rules in `CONVENTIONS.md`.
+
+## Rationale
+
+Alternatives considered: a wiki (rejected — it drifts from the code and
+has no review gate); long-form design docs per project (rejected — no
+stable identity to cite, and no status lifecycle); comments in code
+(rejected — they record what, never why, and they die with the file).
+
+This record is technology-shaped but numbered `0001`, inside the
+capability range, because the adoption of the method has to be the first
+entry in the catalogue it creates. `CONVENTIONS.md` records the
+exception.
+
+## Consequences
+
+Every subsequent decision is written down before it is built. The
+catalogue becomes a review surface, and the number becomes the citable
+identity.
+
+## Acceptance criteria
+
+1. `CONVENTIONS.md` records the authoring rules.
+2. `adr/` holds one file per decision, numbered contiguously.
+3. `INDEX.md` is regenerated from ADR metadata.
+
+## Out of scope
+
+- Backfilling decisions predating this record.
+
+## References
+
+- `CONVENTIONS.md`
+
+## Revision History
+
+| Date | Revision | Author | Change |
+|------|----------|--------|--------|
+| 2026-01-12 | r1 | eval-bot | Initial record of the adopted method. |
+
+## Approvals
+
+| Role | Name | Date | Signature |
+|------|------|------|-----------|
+| Maintainer | eval-bot | 2026-01-12 | — |

--- a/evals/fixtures/legacy-range/adr/0002-searchable-decision-catalogue.md
+++ b/evals/fixtures/legacy-range/adr/0002-searchable-decision-catalogue.md
@@ -1,0 +1,60 @@
+---
+adr: 0002
+title: A searchable decision catalogue
+status: Implemented
+date: 2026-01-19
+owner: eval-bot
+supersedes:
+superseded-by:
+depends-on: ["0001"]
+tags: [fixture]
+---
+
+# ADR 0002 — A searchable decision catalogue
+
+## Context
+
+A reader needs to find the decision governing an area without reading
+every file in `adr/`.
+
+## Capability statement
+
+The catalogue is searchable by number, title and status from a single
+generated index, and every record is reachable by a stable relative path.
+
+## User stories / scenarios
+
+- As a reviewer, I open `INDEX.md` and find the record governing an area
+  by title.
+- As an author, I cite a decision by its relative path and the link
+  resolves from anywhere in the repository.
+
+## Acceptance criteria
+
+1. `INDEX.md` lists every record with number, title, status and date.
+2. Every index row links to an existing file.
+3. Cross-references between records use relative paths.
+
+## Out of scope
+
+- Full-text search over record bodies.
+
+## Open questions
+
+- None.
+
+## References
+
+- adr/0001-record-architecture-decisions.md
+
+## Revision History
+
+| Date | Revision | Author | Change |
+|------|----------|--------|--------|
+| 2026-01-19 | r1 | eval-bot | Initial draft. |
+
+## Approvals
+
+| Role | Name | Date | Signature |
+|------|------|------|-----------|
+| Maintainer | eval-bot | 2026-01-19 | — |

--- a/evals/fixtures/legacy-range/adr/0003-queue-driven-implementation.md
+++ b/evals/fixtures/legacy-range/adr/0003-queue-driven-implementation.md
@@ -1,0 +1,61 @@
+---
+adr: 0003
+title: Queue-driven implementation
+status: Accepted
+date: 2026-02-02
+owner: eval-bot
+supersedes:
+superseded-by:
+depends-on: ["0002", "0101"]
+tags: [fixture]
+---
+
+# ADR 0003 — Queue-driven implementation
+
+## Context
+
+Accepted decisions need a visible unit of work, or they sit unbuilt.
+
+## Capability statement
+
+Every accepted decision has one queued work item naming it as owner, and
+the move from `plan/todo/` to `plan/done/` is the completion event that
+advances the owning record to `Implemented`.
+
+## User stories / scenarios
+
+- As a maintainer, I see what is queued and what shipped without reading
+  the git log.
+- As an agent, I take the lowest-numbered item in `plan/todo/` and build
+  exactly its scope.
+
+## Acceptance criteria
+
+1. Every `Accepted` record has a `plan/todo/` item naming it.
+2. Every `Implemented` record has a `plan/done/` entry.
+3. A shipped entry names the shipping commit.
+
+## Out of scope
+
+- Estimating or scheduling queued items.
+
+## Open questions
+
+- None.
+
+## References
+
+- adr/0002-searchable-decision-catalogue.md
+- adr/0101-markdown-files-in-git.md
+
+## Revision History
+
+| Date | Revision | Author | Change |
+|------|----------|--------|--------|
+| 2026-02-02 | r1 | eval-bot | Initial draft. |
+
+## Approvals
+
+| Role | Name | Date | Signature |
+|------|------|------|-----------|
+| Maintainer | eval-bot | 2026-02-02 | — |

--- a/evals/fixtures/legacy-range/adr/0100-template.md
+++ b/evals/fixtures/legacy-range/adr/0100-template.md
@@ -1,0 +1,42 @@
+---
+adr: NNNN
+title: <Sentence case title>
+status: Proposed
+date: YYYY-MM-DD
+owner: <name>
+supersedes:
+superseded-by:
+depends-on: []
+tags: []
+---
+
+# ADR NNNN — <title>
+
+<!-- Technology ADR. Numbered 0100 or above — see CONVENTIONS.md
+     §ADR Shapes. -->
+
+## Context
+
+## Decision
+
+## Rationale
+
+## Consequences
+
+## Acceptance criteria
+
+## Out of scope
+
+## Open questions
+
+## References
+
+## Revision History
+
+| Date | Revision | Author | Change |
+|------|----------|--------|--------|
+
+## Approvals
+
+| Role | Name | Date | Signature |
+|------|------|------|-----------|

--- a/evals/fixtures/legacy-range/adr/0101-markdown-files-in-git.md
+++ b/evals/fixtures/legacy-range/adr/0101-markdown-files-in-git.md
@@ -1,0 +1,63 @@
+---
+adr: 0101
+title: Markdown files in git as the store
+status: Implemented
+date: 2026-01-19
+owner: eval-bot
+supersedes:
+superseded-by:
+depends-on: ["0002"]
+tags: [fixture]
+---
+
+# ADR 0101 — Markdown files in git as the store
+
+## Context
+
+The catalogue promised by adr/0002-searchable-decision-catalogue.md needs
+somewhere to live.
+
+## Decision
+
+Store every record as a Markdown file in the repository, versioned by git.
+No database, no external service.
+
+## Rationale
+
+Alternatives considered: a hosted wiki (rejected — the records would not
+move with a branch, so a decision and the code implementing it could not
+be reviewed together); a database behind a small service (rejected — it
+adds an availability dependency to reading a decision, and diffs stop
+being reviewable); an issue tracker (rejected — issues close, decisions
+do not, and the tracker has no stable ordering).
+
+## Consequences
+
+Records are reviewed like code and branch with it. The trade-off is that
+renaming a file is a real refactor: every relative link has to follow.
+
+## Acceptance criteria
+
+1. Each record is one Markdown file under `adr/`.
+2. Records are versioned with the code, in the same repository.
+3. Relative links between records resolve from a plain checkout.
+
+## Out of scope
+
+- Rendering the catalogue as a site.
+
+## References
+
+- adr/0002-searchable-decision-catalogue.md
+
+## Revision History
+
+| Date | Revision | Author | Change |
+|------|----------|--------|--------|
+| 2026-01-19 | r1 | eval-bot | Initial draft. |
+
+## Approvals
+
+| Role | Name | Date | Signature |
+|------|------|------|-----------|
+| Maintainer | eval-bot | 2026-01-19 | — |

--- a/evals/fixtures/legacy-range/adr/0102-static-verify-script.md
+++ b/evals/fixtures/legacy-range/adr/0102-static-verify-script.md
@@ -1,0 +1,63 @@
+---
+adr: 0102
+title: A static verify script as the gate
+status: Accepted
+date: 2026-02-09
+owner: eval-bot
+supersedes:
+superseded-by:
+depends-on: ["0002", "0101"]
+tags: [fixture]
+---
+
+# ADR 0102 — A static verify script as the gate
+
+## Context
+
+Conventions that nothing checks drift. The catalogue in
+adr/0101-markdown-files-in-git.md is plain files, so the checks can be
+plain file checks.
+
+## Decision
+
+Ship a single dependency-free script that validates numbering, index
+fidelity, status values and section order, and run it before every push.
+
+## Rationale
+
+Alternatives considered: review discipline alone (rejected — it fails
+silently and unevenly); a linter plugin per editor (rejected — it does
+not run in CI and cannot gate a push); a hosted service (rejected — a
+network dependency for a check over local files).
+
+## Consequences
+
+Every convention worth having has to be expressible as a check over
+files, which keeps the conventions concrete.
+
+## Acceptance criteria
+
+1. The script exits non-zero on any violation and names the file.
+2. It needs no network access and no installed dependencies.
+3. It runs before every push.
+
+## Out of scope
+
+- Behavioural checks that need an agent in the loop.
+
+## References
+
+- adr/0002-searchable-decision-catalogue.md
+- adr/0101-markdown-files-in-git.md
+
+## Revision History
+
+| Date | Revision | Author | Change |
+|------|----------|--------|--------|
+| 2026-02-09 | r1 | eval-bot | Initial draft. |
+
+## Approvals
+
+| Role | Name | Date | Signature |
+|------|------|------|-----------|
+| Maintainer | eval-bot | 2026-02-09 | — |

--- a/evals/fixtures/legacy-range/domains/platform/README.md
+++ b/evals/fixtures/legacy-range/domains/platform/README.md
@@ -1,0 +1,10 @@
+# Platform — decisions
+
+Records governing how this repository stores and checks its own
+catalogue.
+
+| ADR | Title | Status |
+|-----|-------|--------|
+| [0002](../../adr/0002-searchable-decision-catalogue.md) | A searchable decision catalogue | Implemented |
+| [0101](../../adr/0101-markdown-files-in-git.md) | Markdown files in git as the store | Implemented |
+| [0102](../../adr/0102-static-verify-script.md) | A static verify script as the gate | Accepted |

--- a/evals/fixtures/legacy-range/plan/README.md
+++ b/evals/fixtures/legacy-range/plan/README.md
@@ -1,0 +1,4 @@
+# Plan queue
+
+`todo/` is pending work, lowest number first. `done/` is shipped work,
+chronological. A `git mv` from `todo/` to `done/` is the completion event.

--- a/evals/fixtures/legacy-range/plan/done/2026-01-12-adopt-the-method.md
+++ b/evals/fixtures/legacy-range/plan/done/2026-01-12-adopt-the-method.md
@@ -1,0 +1,8 @@
+# Adopt the documentation-led method
+
+Owning ADR: adr/0001-record-architecture-decisions.md
+
+Scaffolded `CONVENTIONS.md`, `AGENTS.md`, `adr/`, `INDEX.md` and the plan
+queue; recorded the adoption as the first entry in the catalogue.
+
+Shipped at HEAD `a1b2c3d4e5f6a7b8` on 2026-01-12.

--- a/evals/fixtures/legacy-range/plan/done/2026-01-19-catalogue-and-store.md
+++ b/evals/fixtures/legacy-range/plan/done/2026-01-19-catalogue-and-store.md
@@ -1,0 +1,9 @@
+# Searchable catalogue on a git-backed store
+
+Owning ADRs: adr/0002-searchable-decision-catalogue.md,
+adr/0101-markdown-files-in-git.md
+
+Generated `INDEX.md` from record metadata and settled the store: Markdown
+files in git, cross-referenced by relative path.
+
+Shipped at HEAD `b2c3d4e5f6a7b8c9` on 2026-01-19.

--- a/evals/fixtures/legacy-range/plan/todo/0001-verify-script-coverage.md
+++ b/evals/fixtures/legacy-range/plan/todo/0001-verify-script-coverage.md
@@ -1,0 +1,21 @@
+# 0001 — Verify script coverage
+
+Owning ADR: adr/0102-static-verify-script.md
+
+## Scope
+
+Write the static verify script and wire it into the pre-push path:
+numbering within each range, index fidelity, status values, section order
+per shape.
+
+## Exit criteria
+
+Maps to adr/0102-static-verify-script.md acceptance criteria:
+
+1. Non-zero exit on any violation, naming the file. -> AC1
+2. No network access and no installed dependencies. -> AC2
+3. Runs before every push. -> AC3
+
+## Dependencies
+
+- adr/0101-markdown-files-in-git.md is already Implemented.

--- a/evals/fixtures/legacy-range/plan/todo/0002-queue-and-completion-event.md
+++ b/evals/fixtures/legacy-range/plan/todo/0002-queue-and-completion-event.md
@@ -1,0 +1,20 @@
+# 0002 — Queue and completion event
+
+Owning ADR: adr/0003-queue-driven-implementation.md
+
+## Scope
+
+Create `plan/todo/` and `plan/done/`, document the completion event, and
+make the status advance part of the same commit.
+
+## Exit criteria
+
+Maps to adr/0003-queue-driven-implementation.md acceptance criteria:
+
+1. Every Accepted record has a todo item. -> AC1
+2. Every Implemented record has a done entry. -> AC2
+3. Shipped entries name the shipping commit. -> AC3
+
+## Dependencies
+
+None.

--- a/plugins/docflow/skills/audit/SKILL.md
+++ b/plugins/docflow/skills/audit/SKILL.md
@@ -222,6 +222,14 @@ Compute the map and show it **before touching a single file**:
   technology ADRs `0101`, `0102`, `0104`, the map is `0101 → 0013`,
   `0102 → 0014`, `0104 → 0015`. Order is preserved; gaps in the old
   technology block are closed, not carried over.
+- **The moved set is the technology *range*, not every technology-shaped
+  ADR.** The range encoding forces one exception — the ADR that adopts
+  the method is a technology-shaped decision that has to be first in the
+  sequence — and repos record it as such in their conventions. It is
+  below the cutoff, so it does **not** move: it keeps its number and
+  simply gains `shape: technology`, which is what retires the exception
+  clause in step 6. Renumbering it would churn the one number every
+  early commit cites, for nothing.
 
 Render the map as an `old → new` table with each ADR's title, then list
 what follows from it: every `depends-on`, `supersedes` /

--- a/plugins/docflow/skills/audit/SKILL.md
+++ b/plugins/docflow/skills/audit/SKILL.md
@@ -12,9 +12,10 @@ This is the enforcement `AGENTS.md` cannot guarantee on its own.
 
 1. Confirm the repo is bootstrapped.
 2. Read `CONVENTIONS.md` to learn what to enforce: the **ADR shape
-   scheme** — a single shape, or two shapes declared by a `shape:` field
-   in each ADR's metadata block (no number boundary is recorded and none
-   is read) — status lifecycle, integration model, multi-agent mode,
+   scheme** — a single shape, two shapes declared by a `shape:` field in
+   each ADR's metadata block (no number boundary is recorded and none is
+   read), or the **legacy range encoding** described in item 4 — status
+   lifecycle, integration model, multi-agent mode,
    language mandate, optional artefacts present (GLOSSARY, domains/),
    and any Q10 domain hard rules, and the **artefact root** (default:
    repository root) — resolve `adr/`, `plan/`, `INDEX.md` against it and
@@ -24,6 +25,23 @@ This is the enforcement `AGENTS.md` cannot guarantee on its own.
    index-holder, or a plain `member`) and read the recorded identity
    scheme; the cross-repo checks (check 12) run from the index-holding
    repo.
+4. **Legacy range encoding.** Some two-shape repos were scaffolded
+   before the shape became a declared field and encode it in the
+   **number** instead: capability ADRs below a cutoff, technology ADRs
+   at or above it, and the technology template sitting at the boundary
+   as a pseudo-ADR. Two signals identify it, and **either one alone is
+   enough**:
+   - `CONVENTIONS.md` §ADR Shapes records a cutoff — a capability range
+     and a technology range rather than a `shape:` field; or
+   - `adr/` holds a template file numbered other than `0000` (e.g.
+     `adr/0100-template.md`, or whatever boundary the project chose).
+
+   Treat the two as one condition, not two findings. When it holds the
+   catalogue is **valid, not broken** — it predates the declared field.
+   Run the checks below under the **legacy rules** noted against
+   checks 1, 2 and 4, so a repo that passed before keeps passing, and
+   report the single finding of check 15. A migration onto the declared
+   field is offered in Step 4; nothing is rewritten here.
 
 ## Step 1 — Run the checks (read-only)
 
@@ -33,16 +51,25 @@ relevant):
 **Templates are not decisions.** Every check that walks the catalogue
 excludes each `adr/0000-*.md` file — `0000-template.md` and, in a
 two-shape repo, `0000-template-technology.md`. They are never numbered,
-indexed, plan-covered, or section-checked as ADRs.
+indexed, plan-covered, or section-checked as ADRs. Under the **legacy
+range encoding** the boundary-numbered template is excluded in exactly
+the same way: it is a template, not the first technology ADR.
 
 1. **Numbering.** ADR filenames contiguous, zero-padded, no gaps, no
    duplicates — **one sequence for the whole catalogue**, whatever each
    ADR's shape. Flag any template numbered other than `0000`.
+   *Legacy encoding:* apply the range rules exactly as they stood —
+   numbering contiguous **within each block** with no duplicates, the
+   gap at the cutoff expected rather than flagged, capability ADRs below
+   the cutoff and technology ADRs at or above it, and the
+   boundary-numbered template neither flagged nor counted as an ADR.
 2. **INDEX sync.** Every ADR appears in `INDEX.md`; every INDEX row has
    a matching file; metadata fields (status, title, date) agree. In a
    two-shape repo the table carries a **Shape** column and its values
    agree with each ADR's `shape:` field (an absent field reads as
    `capability`); a single-shape repo has no such column.
+   *Legacy encoding:* the table carries no Shape column — shape is read
+   from the range — so do not flag its absence.
 3. **Plan coverage.** Every `Accepted` ADR has a `plan/todo/` item;
    every `Implemented` ADR has a `plan/done/` entry. Flag orphans both
    ways.
@@ -56,6 +83,11 @@ indexed, plan-covered, or section-checked as ADRs.
    `capability` nor `technology`. A `shape:` field in a single-shape repo
    is redundant, not wrong — report it as hygiene. Acceptance criteria
    are numbered.
+   *Legacy encoding:* the shape is the ADR's side of the cutoff — below
+   it capability, at or above it technology — and no `shape:` field is
+   expected. Validate the section order against that, exactly as before.
+   A `shape:` field contradicting the range is a real inconsistency; one
+   agreeing with it is hygiene, not a failure.
 5. **Status validity.** Every `status:` is in the declared lifecycle.
    `Superseded` ADRs name a successor in `superseded-by:`; the successor
    names them in `supersedes:` (symmetry).
@@ -135,13 +167,26 @@ indexed, plan-covered, or section-checked as ADRs.
     file exists, surface it as an **offer** to add one (external tools
     discover the catalogue through it) — never as a hard failure;
     migration is offered, not forced.
+15. **Legacy shape encoding.** N/A unless Step 0 item 4 holds. When it
+    does, report exactly **one** finding at severity **migration
+    available**: name the signal(s) that identified the encoding (the
+    cutoff recorded in §ADR Shapes, the boundary-numbered template file,
+    or both), state that the catalogue is valid and passing under the
+    range rules, and say that a complete mechanical migration onto the
+    declared-field scheme is available (Step 4). Never split it into a
+    second finding — a template numbered off `0000` and a recorded
+    cutoff are the same condition — and never fail the audit for it.
 
 ## Step 2 — Report
 
 Lead with a one-line verdict (clean / N issues). Then the punch list,
 grouped by severity: **blocking** (privacy leaks, status/lifecycle
 violations, broken cross-refs), **drift** (INDEX out of sync, missing
-plan files), **hygiene** (stale locks, formatting).
+plan files), **hygiene** (stale locks, formatting), and **migration
+available** (a superseded scheme the repo can move off — check 15).
+A migration-available finding does not count towards the issue count in
+the verdict and never makes the run dirty: a repo whose only finding is
+that one is **clean, with a migration available**.
 
 ## Step 3 — Offer fixes
 

--- a/plugins/docflow/skills/audit/SKILL.md
+++ b/plugins/docflow/skills/audit/SKILL.md
@@ -197,3 +197,91 @@ acceptance criteria, or remove suspected privacy leaks without the
 user confirming each — those need judgement. Commit fixes as
 `fix(adr): ...` / `docs: ...` with a `Rationale:` footer where an ADR
 is touched.
+
+If check 15 fired, offer the **legacy range migration** here too — as
+its own offer, separate from the mechanical fixes above, and never
+bundled into a "fix everything" confirmation. Step 4 is the procedure.
+
+## Step 4 — Offer the legacy range migration (only when check 15 fired)
+
+The migration is **offered, never forced**. A repo that declines keeps
+the range encoding, keeps passing under the legacy rules, and is offered
+again on the next audit. Nothing below is written without the
+confirmation in 4.2.
+
+### 4.1 — Dry run: show the old-to-new number map
+
+Compute the map and show it **before touching a single file**:
+
+- **Capability ADRs** — those below the cutoff — keep their numbers.
+  Nothing moves, so the numbers already cited in commits, tickets and
+  shipped plan entries still resolve.
+- **Technology ADRs** — those at or above the cutoff — take the numbers
+  immediately following the **highest capability ADR**, in their
+  original relative order. With capability ADRs ending at `0012` and
+  technology ADRs `0101`, `0102`, `0104`, the map is `0101 → 0013`,
+  `0102 → 0014`, `0104 → 0015`. Order is preserved; gaps in the old
+  technology block are closed, not carried over.
+
+Render the map as an `old → new` table with each ADR's title, then list
+what follows from it: every `depends-on`, `supersedes` /
+`superseded-by`, relative `adr/NNNN-*.md` link, `INDEX.md` row, domain
+`README.md` listing, and `plan/todo/` owning-ADR reference that names a
+moved number; the boundary template replaced by
+`adr/0000-template-technology.md`; §ADR Shapes rewritten to the declared
+field. Say plainly what is **not** touched: `plan/done/` footers, commit
+messages, tags, and any reference from outside the catalogue. Those are
+history, and history is not rewritten.
+
+### 4.2 — Confirm
+
+Ask for an explicit confirmation of **that map**. Write nothing without
+it. Acceptance of the audit report is not acceptance of the migration:
+ask for it as its own question, and take silence or ambiguity as a no.
+
+### 4.3 — Apply, as one commit
+
+1. `git mv` each moved technology ADR to its new number, keeping its
+   slug. Capability files do not move.
+2. In each moved file, update the `adr:` metadata field and the H1
+   heading to the new number.
+3. Write `shape:` on **every** ADR — `technology` on the moved ones,
+   `capability` on the ones that stayed. Write it explicitly on both:
+   the field is the encoding now, and a catalogue that carries it only
+   on half its ADRs is still readable but no longer self-describing.
+4. Rewrite every in-catalogue reference to a moved number: `depends-on:`,
+   `supersedes:`, `superseded-by:`, relative `adr/NNNN-*.md` links in
+   any ADR body, `INDEX.md` rows, domain `README.md` listings, and the
+   owning-ADR line of every `plan/todo/` item. Rewrite by resolved
+   identity, not by text search alone — a bare `0101` in prose may be a
+   quantity, and a number that did **not** move must not be touched.
+5. Delete the boundary-numbered template and write
+   `adr/0000-template-technology.md` in its place — the technology
+   template, `shape: technology` pre-filled. `adr/0000-template.md`
+   stays as the capability template; no template carries any other
+   number afterwards.
+6. Rewrite `CONVENTIONS.md` §ADR Shapes to the declared-field form: two
+   shapes named by the field, an absent field meaning capability, one
+   contiguous sequence with no boundary, both templates numbered
+   `0000`, and a Shape column in `INDEX.md`. Delete the cutoff, and
+   delete any clause recording the seed ADR as an exception to the
+   range — under the declared field the seed is simply
+   `shape: technology`, and there is nothing to except. If `AGENTS.md`
+   mirrors the section, give it the matching shape hard rules.
+7. Regenerate `INDEX.md` from the new metadata, with the **Shape**
+   column.
+8. Commit **once**. The message lists **every** old-to-new pair, one per
+   line, so the renumbering is reconstructible from history alone — it
+   is the only record of the old numbers, and there is no alias field to
+   fall back on. Conventional Commit, with the `Rationale:` footer the
+   repo's git contract requires for ADR changes.
+
+### 4.4 — Verify before handing back
+
+Re-run Step 1 with the legacy rules **off**: one contiguous sequence,
+each ADR's sections matching its declared shape, a Shape column whose
+values agree with the fields, every relative link resolving, and no
+template numbered other than `0000`. The catalogue must pass with **no
+manual edit**. If anything fails, the migration is incomplete — finish
+it in the same commit rather than leaving a half-migrated catalogue,
+which is the one state neither rule set describes.

--- a/plugins/docflow/skills/audit/SKILL.md
+++ b/plugins/docflow/skills/audit/SKILL.md
@@ -260,7 +260,8 @@ ask for it as its own question, and take silence or ambiguity as a no.
 4. Rewrite every in-catalogue reference to a moved number: `depends-on:`,
    `supersedes:`, `superseded-by:`, relative `adr/NNNN-*.md` links in
    any ADR body, `INDEX.md` rows, domain `README.md` listings, and the
-   owning-ADR line of every `plan/todo/` item. Rewrite by resolved
+   owning-ADR line — and any other relative ADR link — of every
+   `plan/todo/` item. Rewrite by resolved
    identity, not by text search alone — a bare `0101` in prose may be a
    quantity, and a number that did **not** move must not be touched.
 5. Delete the boundary-numbered template and write

--- a/plugins/docflow/skills/audit/SKILL.md
+++ b/plugins/docflow/skills/audit/SKILL.md
@@ -85,9 +85,15 @@ the same way: it is a template, not the first technology ADR.
    are numbered.
    *Legacy encoding:* the shape is the ADR's side of the cutoff — below
    it capability, at or above it technology — and no `shape:` field is
-   expected. Validate the section order against that, exactly as before.
-   A `shape:` field contradicting the range is a real inconsistency; one
-   agreeing with it is hygiene, not a failure.
+   expected. Validate the section order against that, exactly as before,
+   with the one carve-out the encoding forces and these repos record for
+   themselves: an ADR below the cutoff that `CONVENTIONS.md` names as a
+   **documented exception** — typically the ADR adopting the method,
+   which is technology-shaped but has to be first in the sequence — is
+   checked against the technology order, not flagged. A mismatch the
+   conventions do **not** record is still a finding. A `shape:` field
+   contradicting the range is a real inconsistency; one agreeing with it
+   is hygiene, not a failure.
 5. **Status validity.** Every `status:` is in the declared lifecycle.
    `Superseded` ADRs name a successor in `superseded-by:`; the successor
    names them in `supersedes:` (symmetry).
@@ -253,10 +259,15 @@ ask for it as its own question, and take silence or ambiguity as a no.
    slug. Capability files do not move.
 2. In each moved file, update the `adr:` metadata field and the H1
    heading to the new number.
-3. Write `shape:` on **every** ADR — `technology` on the moved ones,
-   `capability` on the ones that stayed. Write it explicitly on both:
-   the field is the encoding now, and a catalogue that carries it only
-   on half its ADRs is still readable but no longer self-describing.
+3. Write `shape:` on **every** ADR — the shape each one **actually
+   has**, not the block it came from. `technology` on the moved ones and
+   on the documented exception that stayed (4.1); `capability` on the
+   rest. Stamping the exception `capability` because it did not move
+   would put the field at odds with its sections, and the check in 4.4
+   would fail the catalogue the migration just produced. Write the field
+   explicitly on all of them: it is the encoding now, and a catalogue
+   carrying it on only half its ADRs is still readable but no longer
+   self-describing.
 4. Rewrite every in-catalogue reference to a moved number: `depends-on:`,
    `supersedes:`, `superseded-by:`, relative `adr/NNNN-*.md` links in
    any ADR body, `INDEX.md` rows, domain `README.md` listings, and the

--- a/plugins/docflow/skills/bootstrap/SKILL.md
+++ b/plugins/docflow/skills/bootstrap/SKILL.md
@@ -48,6 +48,39 @@ Inspect the repo before asking anything.
   repo in the state the Step 4.5 cross-check calls a contradiction: a
   technology template that a single-shape scheme will never select.
 
+  **A repo already on the legacy range encoding gets the migration
+  offer instead.** Some two-shape repos were scaffolded before the shape
+  became a declared field and encode it in the **number**: §ADR Shapes
+  records a cutoff (capability below it, technology at or above), and
+  `adr/` holds a template numbered other than `0000` (e.g.
+  `adr/0100-template.md`). Either signal alone identifies it. Such a repo
+  is not missing a layer — it has both shapes already — so do not offer
+  the scheme switch above, which would strand it with two rival
+  encodings. Offer the **migration onto the declared field**, on the same
+  terms the audit skill uses:
+
+  - Show the **old-to-new number map first**, as a dry run: capability
+    ADRs keep their numbers; technology ADRs take the numbers following
+    the highest capability ADR, in their original relative order.
+    Alongside it, list the references that follow (`depends-on`,
+    `supersedes` / `superseded-by`, relative `adr/NNNN-*.md` links,
+    `INDEX.md`, domain `README.md` listings, `plan/todo/` owning-ADR
+    lines) and what is left as history (`plan/done/` footers, commit
+    messages, tags).
+  - **Write nothing without an explicit confirmation of that map.**
+    Declining is a valid outcome: the repo keeps the range encoding and
+    keeps passing its own rules.
+  - On confirmation, apply the migration exactly as the **audit** skill's
+    migration step specifies — renumber, stamp `shape:` on every ADR,
+    rewrite every in-catalogue reference, replace the boundary template
+    with `adr/0000-template-technology.md`, rewrite §ADR Shapes to the
+    declared field and drop any seed-ADR exception clause, regenerate
+    `INDEX.md` with the Shape column — and land it as **one commit whose
+    message lists every old-to-new pair**. That procedure is the single
+    source of truth; do not paraphrase a second variant of it here.
+  - Then continue the re-run normally for the layers that really are
+    absent (`plan/`, `_agent/`, `GLOSSARY.md`, `domains/`).
+
 State which situation applies in one line before asking the assessment
 questions.
 

--- a/plugins/docflow/skills/new-adr/SKILL.md
+++ b/plugins/docflow/skills/new-adr/SKILL.md
@@ -35,7 +35,9 @@ Author one new ADR, consistent with this repo's conventions.
    and the remedy is the migration, never crossing the boundary.
 3. Read `INDEX.md` and `ls adr/` to learn existing numbers and titles.
    Ignore every `adr/0000-*.md` file — the templates are not decisions
-   and hold no number in the sequence.
+   and hold no number in the sequence. Under the legacy range encoding,
+   ignore the boundary-numbered template the same way: it is a template,
+   not the first technology ADR.
 4. If a `federation.md` exists, this repo is part of a multi-repo
    product. Note the **identity scheme** and the **home** it records —
    they govern numbering and cross-repo references below.
@@ -99,6 +101,8 @@ Questions (skip any the request already answers):
   zero-padded to 4 digits. No gaps, no reuse. **The shape does not
   affect the number** — capability and technology ADRs share one
   contiguous sequence, and neither `0000-` template counts towards it.
+  *Legacy range encoding:* the number is instead the next contiguous one
+  **within this ADR's block**, per Step 0 item 2.
   **In a federation** (a `federation.md` exists), number contiguously
   **within this repo** — numbers are not unique across the federation.
   The ADR's federation identity is the recorded scheme applied to this

--- a/plugins/docflow/skills/new-adr/SKILL.md
+++ b/plugins/docflow/skills/new-adr/SKILL.md
@@ -20,6 +20,19 @@ Author one new ADR, consistent with this repo's conventions.
    it isn't obvious), the multi-agent mode, and the **artefact root**
    (default: repository root) — resolve `adr/` and `INDEX.md` against it
    (`AGENTS.md`/`CLAUDE.md` stay at the repo root).
+   **Legacy range encoding.** A repo scaffolded before the shape became
+   a declared field encodes it in the number instead — §ADR Shapes
+   records a cutoff, or `adr/` holds a template numbered other than
+   `0000` (e.g. `adr/0100-template.md`); either signal alone identifies
+   it. Say so, and offer the migration onto the declared field (the
+   **audit** skill carries the procedure) before authoring. If the
+   operator declines, author under the repo's own rules: read the cutoff
+   and place this ADR on its side of it — capability below, technology
+   at or above, next contiguous **within that block** — using the
+   boundary-numbered template for a technology ADR, and write **no**
+   `shape:` field, which that repo does not use. If the block this ADR
+   belongs to has reached the cutoff, stop and say so: the range is full,
+   and the remedy is the migration, never crossing the boundary.
 3. Read `INDEX.md` and `ls adr/` to learn existing numbers and titles.
    Ignore every `adr/0000-*.md` file — the templates are not decisions
    and hold no number in the sequence.

--- a/plugins/docflow/skills/new-adr/SKILL.md
+++ b/plugins/docflow/skills/new-adr/SKILL.md
@@ -97,6 +97,13 @@ Questions (skip any the request already answers):
   `adr/0000-template-technology.md` for technology — and **write the
   chosen value into the ADR's `shape:` field**. Both templates are
   numbered `0000` and are never themselves catalogue entries.
+  *Legacy range encoding (migration declined):* the repo has two shapes
+  but declares neither. Still ask which one, then take the template from
+  the repo's own scheme — `adr/0000-template.md` for capability, the
+  **boundary-numbered** template for technology — and write **no**
+  `shape:` field. Introducing the field on one ADR would leave the
+  catalogue with two rival encodings, which is the state neither rule
+  set describes.
 - **Number.** Next contiguous integer after the highest existing ADR,
   zero-padded to 4 digits. No gaps, no reuse. **The shape does not
   affect the number** — capability and technology ADRs share one
@@ -138,8 +145,9 @@ If this ADR replaces an existing one:
 
 - Copy the chosen template, fill all placeholders. Status `Proposed`,
   today's date, owner = current agent/human. In a two-shape repo, set
-  `shape:` to the shape chosen in Step 1; in a single-shape repo omit
-  the field entirely.
+  `shape:` to the shape chosen in Step 1; in a single-shape repo — and
+  in a legacy range-encoded one, where the number carries the shape —
+  omit the field entirely.
 - Seed the Revision History with an `r1 — Initial draft` row. Leave the
   Approvals table empty (it populates on Accepted).
 - **Do not invent acceptance criteria or rationale to fill space.** If
@@ -149,8 +157,11 @@ If this ADR replaces an existing one:
 
 - Regenerate `INDEX.md` from ADR metadata. In a two-shape repo the table
   carries a **Shape** column, filled from each ADR's `shape:` field (an
-  absent field renders as `capability`); a single-shape repo has none.
-  Neither `0000-` template is a catalogue entry, so neither appears.
+  absent field renders as `capability`); a single-shape repo has none,
+  and neither does a legacy range-encoded one — its shape is read from
+  the range, so adding the column would encode it twice. Neither `0000-`
+  template is a catalogue entry, so neither appears; under the legacy
+  encoding the boundary-numbered template is excluded the same way.
 - If `domains/` exists, add the ADR to the owning domain's `README.md`
   ADR list. If you assign the ADR to a domain that doesn't exist yet, offer
   to create `domains/<slug>/README.md` (at the recorded artefact root) and


### PR DESCRIPTION
Plan item 0037 (`plan/todo/0037-legacy-range-detection-and-migration.md`), owning ADR `adr/0035-range-numbered-catalogue-migration.md` (Accepted).

Catalogues that still encode the capability/technology distinction as a **number range** — a cutoff in `CONVENTIONS.md` §ADR Shapes, a technology template at the boundary (`adr/0100-template.md`), technology ADRs above it — keep working exactly as before, and are offered a complete mechanical migration onto the `shape:` field that plan 0036 introduced. Nothing is rewritten without an explicit confirmation of a shown old-to-new number map.

## What changed, per scope item

**1. Detection** (`audit`). Step 0 gains a legacy-encoding item: either signal alone — a recorded cutoff, or a template numbered other than `0000` — identifies the scheme, and the two are one condition, never two findings. While it holds, checks 1, 2 and 4 apply the range rules as they stood (contiguous *within each block*, the gap at the cutoff expected, no Shape column required, section order read from the ADR's side of the cutoff, the boundary template excluded like any template), so a legacy repo that passed keeps passing. New check 15 reports the encoding as one finding at a new severity, **migration available**, which does not count towards the verdict's issue count and never fails the run.

**2. Offer** (`audit` Step 3/4, `bootstrap` Step 1). Audit offers the migration as its own offer, never bundled into "fix everything". Bootstrap's already-a-docflow-repo path recognises the same two signals and makes the same offer — deliberately *instead* of the second-shape scheme switch, which would leave such a repo with two rival encodings — with the same dry run and the same confirmation gate, delegating the mechanics to the audit procedure rather than paraphrasing a second variant of it.

**3. Migration procedure** (`audit` Step 4). Dry run first (4.1): capability numbers stay; technology ADRs take the numbers after the highest capability ADR in their original relative order, gaps closed; the map is rendered `old → new` with titles, alongside what follows from it and what is left as history. One exception is called out explicitly: the record that adopts the method is technology-shaped but sits below the cutoff, so it does **not** move — it keeps its number and gains `shape: technology`, which is what retires the "recorded exception" clause. Confirmation (4.2) is its own question; silence is a no. Apply (4.3) as one commit: `git mv`, `adr:`/H1 renumbered, `shape:` written on **every** ADR including the ones that stayed, every in-catalogue reference rewritten (`depends-on`, `supersedes`/`superseded-by`, relative `adr/NNNN-*.md` links, `INDEX.md` rows, domain `README.md` listings, and every relative ADR link in a `plan/todo/` item), boundary template replaced by `adr/0000-template-technology.md`, §ADR Shapes rewritten to the declared form with the exception clause deleted, `INDEX.md` regenerated with the Shape column, and a commit message listing every old-to-new pair. `plan/done/` footers, commit messages and tags are left as history. Verify (4.4) re-runs the checks with the legacy rules off; the catalogue must pass with no manual edit.

**`new-adr`** was added to the item's scope, traced to ADR 0035's capability statement ("recognised by **every** lifecycle skill") and confirmed with the coordinator: as shipped after plan 0036 it reads no cutoff, so authoring a technology ADR in an un-migrated legacy repo would have placed it inside the capability block and broken that repo's own rules — the rules AC2 promises keep applying. It now names the encoding, offers the migration first, and if declined places the ADR on its side of the cutoff (next contiguous within that block, boundary template for a technology ADR, no `shape:` field), stopping with a clear message if that block is full rather than crossing the boundary. **The coordinator will amend the plan item's scope text at ship time.**

**4. Eval** (own commit). `evals/fixtures/legacy-range/` is a checked-in range-numbered catalogue: cutoff `0100` in `CONVENTIONS.md` with the seed exception clause, `adr/0100-template.md` at the boundary, capability `0001`–`0003`, technology `0101`–`0102`, cross-references both ways (`0003 → 0101`, `0102 → 0002` and `0101`), a `plan/todo/` item owned by `0102`, `plan/done/` footers citing `0101`, and a `domains/platform/` listing. A deterministic self-check case guards the fixture's defining properties so it cannot rot into something the migration case would pass against vacuously; a behavioural case drives detection → dry-run offer with nothing written → migration → post-migration audit → the deterministic assertions. New helpers: `assertLegacyRange`, `assertMigratedToDeclaredShape`, `assertReferencesRewritten`, `assertHistoryPreserved`; `listAdrs` now excludes a boundary-numbered template as well as both `0000-` files.

**5. Docs.** `README.md` (a note under the deferred-layer paragraph), `USAGE.md` (new §5b covering the scheme, why it is superseded, what keeps working, the dry-run map, the one-commit migration, what stays history, and that declining is fine — plus pointers from the audit row and §7), `docs/methodology.md` (§4.3: the range encoding recorded as superseded-but-conformant, the three reasons, and the migration's normative shape), `docs/examples.md` (the audit note and offer as a worked example). No ADR identifiers in any user-visible surface — the static gate's privacy scan covers all of them.

## Exit criteria → ADR 0035 acceptance criteria

- [x] **1 — Detected from conventions or template numbering, one non-failing "migration available" finding.** → AC1 — audit Step 0 item 4 + check 15; the two signals are explicitly one condition.
- [x] **2 — Legacy repos keep passing under the range rules until migrated.** → AC2 — legacy clauses on checks 1, 2, 4 and the templates-are-not-decisions note; `new-adr` no longer breaks them either.
- [x] **3 — Audit and bootstrap both offer, show the map, wait for confirmation.** → AC3 — audit Step 3 pointer + Step 4.1/4.2; bootstrap Step 1.
- [x] **4 — Technology ADRs appended after the last capability number in original order; capability numbers unchanged.** → AC4 — Step 4.1, including the below-cutoff exception that keeps its number.
- [x] **5 — Every in-catalogue reference rewritten; `plan/done/` and history left alone.** → AC5 — Step 4.3 items 3–4 and the "not touched" list in 4.1.
- [x] **6 — Boundary template retired, conventions rewritten, exception clause gone.** → AC6 — Step 4.3 items 5–6.
- [x] **7 — Post-migration catalogue passes the two-shape checks with no manual edits.** → AC7 — Step 4.4, and demonstrated: the procedure was applied by hand to a scratch copy of the fixture and `assertMigratedToDeclaredShape` + `assertReferencesRewritten` + `assertHistoryPreserved` all passed against the result.
- [x] **8 — Migration commit message lists every old-to-new pair.** → AC8 — Step 4.3 item 8, with the reason (no alias field; the message is the only bridge between the two numberings).
- [x] **9 — Eval fixture and assertions cover detection, offer, post-migration audit.** → AC9 — `evals/fixtures/legacy-range/`, two cases in `evals/cases.mjs`, one case in `evals/behavioural.workflow.mjs`, four new assertion helpers.
- [x] **10 — Skill parity across all five targets preserved.** → verify gate: one skill source, agent-neutral prose, no manifest changes.

## Gate

```
$ node scripts/verify.mjs
verify: OK (version 0.9.4, 9 skills, 49 ADRs, 46 shipped plan items)
$ echo $?
0
```

```
$ npm run evals
  PASS  self-check: docflow repo satisfies its own invariants
  PASS  self-check: the legacy-range fixture is still range-numbered
  SKIP  audit: legacy range detected, migration offered and applied
  SKIP  bootstrap: fresh repo gets the full scaffold
  SKIP  bootstrap: express depth scaffolds the fixed minimal profile
  SKIP  new-adr: next contiguous number, INDEX regenerated
  SKIP  ship-item: todo→done and owning ADR → Implemented

2 passed, 0 failed, 5 skipped
```

**The new behavioural case was not run from this session.** It is agent-driven and needs the Workflow tool (opt-in, not requested here), and worktree subagents cut from a committed ref would not see these skills until this branch is merged. What *was* run: its deterministic half. The migration procedure in the skill was executed step by step against a scratch copy of the fixture, producing `0101 → 0004`, `0102 → 0005`, `0001`–`0003` unchanged, `0001` carrying `shape: technology`, `adr/0100-template.md` retired for `adr/0000-template-technology.md`, the `plan/todo` owner rewritten to `adr/0005-…`, the domain listing rewritten, `INDEX.md` regenerated with the Shape column, and `plan/done/` still citing `0101` — and all three post-migration assertions passed. The fixture self-check runs green in `npm run evals` above.

Commits: audit detection; the migration procedure across audit/bootstrap/new-adr; docs; the exception refinement; the evals (own commit, gate-integrity reason named in the message); a final three-gap fix. Signed; no `Co-Authored-By`; no `Rationale:` footers, as no commit touches an ADR.

## Status at a glance

- **This run** — implemented plan 0037 end to end: legacy detection and legacy rules in `audit`, the migration procedure with dry run and confirmation gate in `audit`, the same offer in `bootstrap`'s existing-repo path, a legacy clause in `new-adr` (scope addition, coordinator-approved), the `legacy-range` eval fixture with four new assertion helpers and two cases, and docs across README/USAGE/docs. Gate: `verify: OK (version 0.9.4, 9 skills, 49 ADRs, 46 shipped plan items)`, exit code **0**. `npm run evals`: 2 passed, 0 failed, 5 skipped (behavioural).
- **Overall** — implemented and verified by the static gate; the migration procedure additionally demonstrated end-to-end against a scratch copy of the fixture. **Not yet merged.** This repo's own catalogue, `INDEX.md`, `CONVENTIONS.md`, `AGENTS.md`, `scripts/verify.mjs` and the plan queue are untouched.
- **Yet to do** — the ship step, after merge, on `main`: `git mv plan/todo/0037-legacy-range-detection-and-migration.md` → `plan/done/<date>-legacy-range-detection-and-migration.md` with the HEAD-SHA footer, advance `adr/0035-range-numbered-catalogue-migration.md` Accepted → Implemented with a Revision History row, regenerate `INDEX.md`, append the worklog. Also at ship time: amend the plan item's scope text to record `new-adr` as part of item 0037 (agreed with the coordinator). Left undone deliberately: the behavioural eval case has not been executed — it needs the Workflow tool and a merged ref; run it as part of the next release gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Upidh4sxkkvuhyNY3E8Et

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Migration renumbers ADRs and rewrites many references in one mechanical commit—high impact if mis-run, but the skill gates on an explicit map confirmation and evals guard expected outcomes; legacy repos otherwise only change how audit/new-adr interpret conventions.
> 
> **Overview**
> Adds first-class support for **older two-shape catalogues** that encoded capability vs technology by **number range** (cutoff in `CONVENTIONS.md`, boundary template like `adr/0100-template.md`) instead of the declared `shape:` field.
> 
> **`audit`** now recognises that encoding (either signal is enough), runs numbering/INDEX/section checks under **legacy range rules** so existing repos keep passing, surfaces a single non-failing **migration available** finding (check 15), and documents a **confirm-first** migration: dry-run old→new map, one commit that renumbers technology ADRs after the last capability number, stamps `shape:` on every ADR, rewrites in-repo references, retires the boundary template, updates conventions/`INDEX` with a Shape column, and leaves `plan/done` history untouched.
> 
> **`bootstrap`** (existing-repo path) offers the same migration **instead of** adding a second-shape layer when the repo already has both shapes via ranges. **`new-adr`** offers migration first; if declined, it authors on the correct side of the cutoff without introducing `shape:`.
> 
> **Docs** (`README`, `USAGE` §5b, methodology, examples) explain the superseded scheme, the offer, and what changes in one commit.
> 
> **Evals** add `fixtures/legacy-range/`, deterministic helpers (`assertLegacyRange`, `assertMigratedToDeclaredShape`, etc.), a fixture self-check, an agent-dependent migration case, and a behavioural `legacy-range-migration` workflow prompt.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f7ce501275f33cd6fccee48765b49fe4eb69fa0b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->